### PR TITLE
WIP: Remove react duplication in JLab 0.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "@phosphor/coreutils": "^1.3.0",
     "@phosphor/messaging": "^1.2.2",
     "@phosphor/widgets": "^1.6.0",
-    "react": "~16.2.0",
-    "react-dom": "~16.2.0"
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "devDependencies": {
     "@types/react": "~16.0.19",


### PR DESCRIPTION
There are version clashes when installing the extension with JLab 0.34 for react and react-dom:

```bash
WARNING in react
  Multiple versions of react found:
    16.2.0 ./~/@jupyterlab\toc/~/react from ./~/@jupyterlab\toc/~/react\index.js

    16.4.2 ./~/react from ./~/react\index.js


WARNING in react-dom
  Multiple versions of react-dom found:
    16.2.1 ./~/@jupyterlab\toc/~/react-dom from ./~/@jupyterlab\toc/~/react-dom\
index.js
    16.4.2 ./~/react-dom from ./~/react-dom\index.js
```

Nota: I have not tested it. Hence the `WIP`.